### PR TITLE
Fix logfile setup

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,19 +4,20 @@ if [ -z "$(ls -A "$PZ_DIR" 2>/dev/null)" ]; then
     echo "Directory is empty. Proceeding with installation..."
     /steamcmd/steamcmd.sh +force_install_dir "$PZ_DIR" \
         +login anonymous \
-        +app_update $SteamAppId validate \
+        +app_update "$SteamAppId" validate \
         +quit
-    mkdir -p $PZ_DIR/logs
 else
     echo "Directory is not empty. Skipping installation."
 fi
 
-# Ensure necessary directories exist
-chown -R $USER:$GROUP /home/$USER
-chown -R $USER:$GROUP $PZ_DIR
+mkdir -p "$PZ_DIR/logs"
 
-cp -rf $PZ_DIR/linux64/steamclient.so /home/$USER/.steam/sdk64/steamclient.so
-exec > >(tee -a "$$PZ_DIR/logs/server.log") 2>&1
+# Ensure necessary directories exist
+chown -R $USER:$GROUP "/home/$USER"
+chown -R $USER:$GROUP "$PZ_DIR"
+
+cp -rf "$PZ_DIR/linux64/steamclient.so" "/home/$USER/.steam/sdk64/steamclient.so"
+exec > >(tee -a "$PZ_DIR/logs/server.log") 2>&1
 
 chmod +x *.sh
-exec gosu $USER:$GROUP $PZ_DIR/*.sh "${STEAM_ENABLED:+-nosteam}" -adminpassword "${PZ_ADMIN_PASSWORD:-admin}"
+exec gosu $USER:$GROUP "$PZ_DIR"/*.sh "${STEAM_ENABLED:+-nosteam}" -adminpassword "${PZ_ADMIN_PASSWORD:-admin}"


### PR DESCRIPTION
## Summary
- ensure logs directory exists even when server already installed
- sanitize path handling in `entrypoint.sh`

## Testing
- `bash -n docker/entrypoint.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f3b952268832ca8d83e1f3cfca1df